### PR TITLE
P2P Tweaks and Revert on RecvPacketMsg

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -35,7 +35,7 @@ const (
 	maxMsgSize = maxAddressSize * maxGetSelection
 
 	// ensure we have enough peers
-	defaultEnsurePeersPeriod = 5 * time.Minute
+	defaultEnsurePeersPeriod = 2 * time.Minute
 
 	// Seed/Crawler constants
 
@@ -53,7 +53,7 @@ const (
 	biasToSelectNewPeers = 30 // 70 to select good peers
 
 	// if a peer is marked bad, it will be banned for at least this time period
-	defaultBanTime = 168 * time.Hour
+	defaultBanTime = 24 * time.Hour
 )
 
 type errMaxAttemptsToDial struct {


### PR DESCRIPTION
After some testing this changes seems to help with the node getting stuck situation. 

Node running from 02/12/21 -> 02/15/21 with only outbound peers not getting stuck.

-----

Revert recvPacketMsg and Minor p2p tweaks ( lower ensure peer from 5 minutes to 2 and ban time to 24h)
