### PR TITLE
Tendermint minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ terraform.tfstate.d
 .vscode
 
 profile\.out
+
+main

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -1,9 +1,10 @@
 package abcicli
 
 import (
-	types2 "github.com/tendermint/tendermint/types"
 	"sync"
 	"time"
+
+	types2 "github.com/tendermint/tendermint/types"
 
 	types "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/service"

--- a/cmd/tendermint/commands/show_validator.go
+++ b/cmd/tendermint/commands/show_validator.go
@@ -25,10 +25,14 @@ func showValidator(cmd *cobra.Command, args []string) error {
 
 	pv := privval.LoadFilePVLean(keyFilePath, config.PrivValidatorStateFile())
 
-	pubKey, err := pv.GetPubKey()
+	pubKeys, err := pv.GetPubKeys()
 	if err != nil {
 		return errors.Wrap(err, "can't get pubkey")
 	}
+	if len(pubKeys) > 1 {
+		return errors.Wrapf(err, "expected exactly one public key but got %d", len(pubKeys))
+	}
+	pubKey := pubKeys[0]
 
 	bz, err := cdc.MarshalJSON(pubKey)
 	if err != nil {

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -140,10 +140,14 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		pvStateFile := filepath.Join(nodeDir, config.BaseConfig.PrivValidatorState)
 		pv := privval.LoadFilePVLean(pvKeyFile, pvStateFile)
 
-		pubKey, err := pv.GetPubKey()
+		pubKeys, err := pv.GetPubKeys()
 		if err != nil {
 			return errors.Wrap(err, "can't get pubkey")
 		}
+		if len(pubKeys) > 1 {
+			return errors.Wrapf(err, "expected exactly one public key but got %d", len(pubKeys))
+		}
+		pubKey := pubKeys[0]
 		genVals[i] = types.GenesisValidator{
 			Address: pubKey.Address(),
 			PubKey:  pubKey,

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/pokt-network/tendermint
 
 go 1.18
 
-replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4
-
-// replace github.com/tendermint/tendermint => /Users/olshansky/workspace/pocket/v0/tendermint
-// replace github.com/tendermint/tendermint => /go/src/github.com/pokt-network/tendermint
+// replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4
+replace github.com/tendermint/tendermint => /Users/olshansky/workspace/pocket/v0/tendermint
 
 require (
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/pokt-network/tendermint
 
 go 1.18
 
+// TODO: Update the main revision after changes are merged
 replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint main
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,7 @@ module github.com/pokt-network/tendermint
 
 go 1.18
 
-// replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4
-replace github.com/tendermint/tendermint => /Users/olshansky/workspace/pocket/v0/tendermint
+replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint main
 
 require (
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/pokt-network/tendermint
 
-go 1.17
+go 1.18
+
+replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4
+
+// replace github.com/tendermint/tendermint => /Users/olshansky/workspace/pocket/v0/tendermint
+// replace github.com/tendermint/tendermint => /go/src/github.com/pokt-network/tendermint
 
 require (
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
@@ -26,6 +31,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino v0.15.1
+	github.com/tendermint/tendermint v0.0.0-00010101000000-000000000000
 	github.com/tendermint/tm-db v0.5.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4 h1:xH58BhZBHCCxslhvxvzX5t5lu0IAlxsSMtr3xEyiTj4=
-github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4/go.mod h1:K0FjOLKFgqlDB/fy/2cx3BoMgFg6JD2FP3EK/9M3Tlk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -302,6 +301,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4 h1:xH58BhZBHCCxslhvxvzX5t5lu0IAlxsSMtr3xEyiTj4=
+github.com/pokt-network/tendermint v0.32.11-0.20220824215059-3214a152d8d4/go.mod h1:K0FjOLKFgqlDB/fy/2cx3BoMgFg6JD2FP3EK/9M3Tlk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pokt-network/tendermint v0.32.11-0.20221203163855-637a4d695f65 h1:9f+G8YSIYe/vL3IiFwsxmXMD9iIgS6xf7Zzvx4Kr5bg=
+github.com/pokt-network/tendermint v0.32.11-0.20221203163855-637a4d695f65/go.mod h1:K0FjOLKFgqlDB/fy/2cx3BoMgFg6JD2FP3EK/9M3Tlk=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=


### PR DESCRIPTION
- Update to go1.18
- Point tendermint point to its fork because mainline dependencies are ahead
- Added a TODO to update the revision in a subsequent commit